### PR TITLE
Change field type for Google Calendar Event URL to Small Text

### DIFF
--- a/frappe_scheduler/fixtures/custom_field.json
+++ b/frappe_scheduler/fixtures/custom_field.json
@@ -300,7 +300,7 @@
   "fetch_from": null,
   "fetch_if_empty": 0,
   "fieldname": "custom_google_calendar_event_url",
-  "fieldtype": "Data",
+  "fieldtype": "Small Text",
   "hidden": 0,
   "hide_border": 0,
   "hide_days": 0,


### PR DESCRIPTION
## Description

- Fixes issue that value for Google Calendar Event URL is long.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #