### PR TITLE
Enhance duration field inputs

### DIFF
--- a/frappe_scheduler/hooks.py
+++ b/frappe_scheduler/hooks.py
@@ -18,7 +18,7 @@ website_route_rules = [
 
 # include js, css files in header of desk.html
 # app_include_css = "/assets/frappe_scheduler/css/frappe_scheduler.css"
-app_include_js = ["/assets/frappe_scheduler/js/appointment_link.js"]
+app_include_js = ["/assets/frappe_scheduler/js/appointment_link.js", "/assets/frappe_scheduler/js/duration_override.js"]
 
 # include js, css files in header of web template
 # web_include_css = "/assets/frappe_scheduler/css/frappe_scheduler.css"

--- a/frappe_scheduler/public/js/duration_override.js
+++ b/frappe_scheduler/public/js/duration_override.js
@@ -45,11 +45,9 @@ frappe.ui.form.ControlDuration = class extends frappe.ui.form.ControlDuration {
       }
       this.$picker.hide();
     });
+  }
 
-    this.$input.on("change", () => {
-      let value = this.$input.val();
-      let total_duration = duration_string_to_seconds(value);
-      this.set_value(total_duration);
-    });
+  parse(value) {
+    return duration_string_to_seconds(super.parse(value));
   }
 };

--- a/frappe_scheduler/public/js/duration_override.js
+++ b/frappe_scheduler/public/js/duration_override.js
@@ -1,0 +1,55 @@
+function duration_string_to_seconds(value) {
+  if (!value) {
+    return "0";
+  }
+
+  // try to parse int. If success, return it without any conversion
+  if (!isNaN(value)) {
+    return value;
+  }
+
+  let seconds = 0;
+  // parts = [[2, "Days"], [5, "h"], [30, "M"], [10, "sec"]]
+  // using regex, find all the numbers and units, and then convert to seconds
+  let parts = value.match(/(\d+)\s*([a-zA-Z]+)/g);
+  if (parts) {
+    parts.forEach((part) => {
+      let unit = part.match(/[a-zA-Z]/)[0].toLowerCase();
+      let number = cint(part.match(/\d+/)[0]);
+      if (unit === "d") {
+        seconds += number * 24 * 60 * 60;
+      } else if (unit === "h") {
+        seconds += number * 60 * 60;
+      } else if (unit === "m") {
+        seconds += number * 60;
+      } else if (unit === "s") {
+        seconds += number;
+      }
+    });
+  }
+  return seconds.toString();
+}
+
+frappe.ui.form.ControlDuration = class extends frappe.ui.form.ControlDuration {
+  bind_events() {
+    super.bind_events();
+
+    this.$wrapper.find(".duration-input").click((e) => {
+      e.stopPropagation(); // prevent the focus event of $input from firing (in case of child table).
+    });
+
+    this.$wrapper.find(".duration-input").blur((e) => {
+      // if blur event is due to clicking on the picker, or other input box, don't hide the picker.
+      if (e.relatedTarget && e.relatedTarget.classList.contains("duration-input")) {
+        return;
+      }
+      this.$picker.hide();
+    });
+
+    this.$input.on("change", () => {
+      let value = this.$input.val();
+      let total_duration = duration_string_to_seconds(value);
+      this.set_value(total_duration);
+    });
+  }
+};

--- a/frappe_scheduler/public/js/duration_override.js
+++ b/frappe_scheduler/public/js/duration_override.js
@@ -48,6 +48,6 @@ frappe.ui.form.ControlDuration = class extends frappe.ui.form.ControlDuration {
   }
 
   parse(value) {
-    return duration_string_to_seconds(super.parse(value));
+    return duration_string_to_seconds(value);
   }
 };


### PR DESCRIPTION
## Description

- There is an issue with Duration field in child table. This PR fixes the same.
- While entering directly in Duration field (Without using the popup), it only allowed entering value in seconds. This PR enhances this, and allows directly inputting duration in the field, like `1 hour 30 min`, or `1h20m`
- This PR also fixes an issue with closing the popup of Duration field. Sometimes the duration popup didn't seemed to close even when clicking outside the popup.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

- Ensure you can edit duration values without expanding the child table rows in `User Appointment Availability`.
- Ensure you can put values directly in the duration field (without using popup). You can try values like `1 h30m`, `2 hours 10 min`, `1h15m` etc.

## Additional Information:

- Will also make a PR to Frappe to fix it directly in core. Once it is submitted in core, and we update our frappe version, we'll remove it from this app.

## Screenshot/Screencast


https://github.com/user-attachments/assets/32ae809a-621d-41de-bfd6-8e1ebb126774



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

See #141 