### PR TITLE
Fix add function to handle incorrect image file path in banner image

### DIFF
--- a/frontend/src/pages/appointment/components/booking.tsx
+++ b/frontend/src/pages/appointment/components/booking.tsx
@@ -35,11 +35,7 @@ import { useAppContext } from "@/context/app";
 import TimeSlotSkeleton from "./timeSlotSkeleton";
 import TimeZoneSelect from "./timeZoneSelectmenu";
 import { Skeleton } from "@/components/skeleton";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/tooltip";
 import Spinner from "@/components/spinner";
 import useBack from "@/hooks/useBack";
 import SuccessAlert from "@/components/success-alert";
@@ -234,7 +230,9 @@ const Booking = ({ type, banner }: BookingProp) => {
               style={
                 banner
                   ? {
-                      backgroundImage: `url(${window.location.origin}${banner})`,
+                      backgroundImage: `url(${
+                        window.location.origin
+                      }${encodeURI(banner)})`,
                     }
                   : {}
               }


### PR DESCRIPTION
## Description

This PR fixes the incorrect file path issue. Currently, images with spaces in their names (e.g., `"WordA WordB WordC"`) are stored without encoding, leading to incorrect path resolution. This update ensures that image file names are properly encoded before use, allowing for correct display and access in **Personal Meetings**.

## Relevant Technical Choices

- Encode the file path string before using

## Testing Instructions

- Use an image with a filename containing multiple words.

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

![image](https://github.com/user-attachments/assets/aa6580b9-a2fc-41c9-86cb-7373314ff52f)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
