### PR TITLE
Add optional ICS event description to calendar attachment functionality

### DIFF
--- a/frappe_scheduler/helpers/ics_file.py
+++ b/frappe_scheduler/helpers/ics_file.py
@@ -8,7 +8,7 @@ from ics.grammar.parse import ContentLine
 from frappe_scheduler.helpers.utils import convert_datetime_to_utc
 
 
-def add_ics_file_in_attachment(event):
+def add_ics_file_in_attachment(event, ics_event_description=None):
     # Create a calendar
     calendar_object = Calendar()
 
@@ -21,7 +21,7 @@ def add_ics_file_in_attachment(event):
     event_object.end = convert_datetime_to_utc(get_datetime(event.ends_on))
 
     event_object.uid = str(uuid.uuid4())
-    event_object.description = event.description
+    event_object.description = ics_event_description or event.description
 
     if event.appointment_group and event.appointment_group.event_organizer:
         user_name, user_email = frappe.db.get_value(


### PR DESCRIPTION
## Description

- Adds an optional parameter `ics_event_description` in [`frappe_scheduler/helpers/ics_file.py`](https://github.com/rtCamp/frappe-scheduler/compare/develop...fix/ics_file_description?expand=1#diff-19cc6c62954d5b64067565a1c9ea5aa57d16958d9bc1557f2b2f60e8d47cb0ebL11) that allows you to add a custom description to ics file instead of the default description.
- This is required for https://github.com/rtCamp/frappe-careers/pull/71

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

See https://github.com/rtCamp/frappe-careers/pull/71