### PR TITLE
Fix issue `TypeError: cannot unpack non-iterable NoneType object`

### DIFF
--- a/frappe_scheduler/helpers/google_calendar.py
+++ b/frappe_scheduler/helpers/google_calendar.py
@@ -26,7 +26,9 @@ def insert_event_in_google_calendar_override(
     Insert Events in Google Calendar if sync_with_google_calendar is checked.
     """
     if not doc.sync_with_google_calendar or not frappe.db.exists("Google Calendar", {"name": doc.google_calendar}):
-        return
+        if update_doc:
+            return None
+        return None, {}
 
     if not success_msg:
         success_msg = _("Event Synced with Google Calendar.")
@@ -34,7 +36,9 @@ def insert_event_in_google_calendar_override(
     google_calendar, account = get_google_calendar_object(doc.google_calendar)
 
     if not account.push_to_google_calendar:
-        return
+        if update_doc:
+            return None
+        return None, {}
 
     event = {
         "summary": doc.subject,


### PR DESCRIPTION
## Description

- Currently in `insert_event_in_google_calendar_override` function, either one or two values are returned based on the `update_doc` parameter. This was done to handle doctype field updates either directly in the function, or return them as a dict to be handled by the calling function.
- However, in some cases of early return, only one value (None) was being returned despite of the `update_doc` flag.
- This pull request includes a small change to the `frappe_scheduler/helpers/google_calendar.py` file. The change modifies the `insert_event_in_google_calendar_override` function to return `None` or `(None, {})` based on the `update_doc` flag, instead of just returning. This ensures consistent return values when certain conditions are not met.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #