### PR TITLE
fix: Available Slots UI breaks if the Event Availability Window value is high

### DIFF
--- a/frappe_scheduler/frappe_scheduler/doctype/appointment_group/appointment_group.css
+++ b/frappe_scheduler/frappe_scheduler/doctype/appointment_group/appointment_group.css
@@ -1,0 +1,3 @@
+.overflow-x-scroll {
+    overflow-x: scroll;
+}


### PR DESCRIPTION

## Description

Ref: #158 

The appointment page UI breaks if the user selects Event Availability Window values more than 10. It is not about the value; if the table has more items than the default page width, the page view breaks.

This PR fixes it by adding a css class to add a scrollbar for the same.

## Relevant Technical Choices

This pull request includes a small change to the `frappe_scheduler/frappe_scheduler/doctype/appointment_group/appointment_group.css` file. The change adds a new CSS class to enable horizontal scrolling.

* [`frappe_scheduler/frappe_scheduler/doctype/appointment_group/appointment_group.css`](diffhunk://#diff-8e980d911b855498b533b1960d83f74f4a81b2d9367b7185a481fa7a26217173R1-R3): Added `.overflow-x-scroll` class to enable horizontal scrolling.

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #